### PR TITLE
Adding support for checking the contain and require functions

### DIFF
--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -1,7 +1,7 @@
 PuppetLint.new_check(:relative_classname_inclusion) do
   def check
     tokens.each_with_index do |token, token_idx|
-      if token.type == :NAME && token.value == 'include'
+      if token.type == :NAME && ['include','contain','require'].include?(token.value)
         s = token.next_code_token
         in_function = 0
         while s.type != :NEWLINE

--- a/puppet-lint-absolute_classname-check.gemspec
+++ b/puppet-lint-absolute_classname-check.gemspec
@@ -23,5 +23,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rspec-collection_matchers', '~> 1.0'
   spec.add_development_dependency 'mime-types', '~> 1.0' # 2.x dropped Ruby 1.8 support
   spec.add_development_dependency 'coveralls', '~> 0.7' unless RUBY_VERSION =~ /^1\.8/
-  spec.add_development_dependency 'rake'
+  spec.add_development_dependency 'rake', '~> 10.5' # 11.x dropped Ruby 1.8 support
 end

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -19,6 +19,16 @@ describe 'relative_classname_inclusion' do
 
         class foobar {
         }
+
+        contain ::foobar
+        contain('::foobar')
+        contain(foobar(baz))
+        contain(foobar('baz'))
+
+        require ::foobar
+        require('::foobar')
+        require(foobar(baz))
+        require(foobar('baz'))
         EOS
       end
 
@@ -33,17 +43,25 @@ describe 'relative_classname_inclusion' do
         include foobar
         include(foobar)
         class { 'foobar': }
+        contain foobar
+        contain(foobar)
+        require foobar
+        require(foobar)
         EOS
       end
 
-      it 'should detect 3 problems' do
-        expect(problems).to have(3).problems
+      it 'should detect 7 problems' do
+        expect(problems).to have(7).problems
       end
 
       it 'should create warnings' do
         expect(problems).to contain_warning(msg).on_line(1).in_column(17)
         expect(problems).to contain_warning(msg).on_line(2).in_column(17)
         expect(problems).to contain_warning(msg).on_line(3).in_column(17)
+        expect(problems).to contain_warning(msg).on_line(4).in_column(17)
+        expect(problems).to contain_warning(msg).on_line(5).in_column(17)
+        expect(problems).to contain_warning(msg).on_line(6).in_column(17)
+        expect(problems).to contain_warning(msg).on_line(7).in_column(17)
       end
     end
   end
@@ -72,6 +90,16 @@ describe 'relative_classname_inclusion' do
 
         class foobar {
         }
+
+        contain ::foobar
+        contain('::foobar')
+        contain(foobar(baz))
+        contain(foobar('baz'))
+
+        require ::foobar
+        require('::foobar')
+        require(foobar(baz))
+        require(foobar('baz'))
         EOS
       end
 
@@ -86,17 +114,25 @@ describe 'relative_classname_inclusion' do
         include foobar
         include(foobar)
         class { 'foobar': }
+        contain foobar
+        contain(foobar)
+        require foobar
+        require(foobar)
         EOS
       end
 
-      it 'should detect 3 problems' do
-        expect(problems).to have(3).problems
+      it 'should detect 7 problems' do
+        expect(problems).to have(7).problems
       end
 
       it 'should fix the problems' do
         expect(problems).to contain_fixed(msg).on_line(1).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(2).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(3).in_column(17)
+        expect(problems).to contain_fixed(msg).on_line(4).in_column(17)
+        expect(problems).to contain_fixed(msg).on_line(5).in_column(17)
+        expect(problems).to contain_fixed(msg).on_line(6).in_column(17)
+        expect(problems).to contain_fixed(msg).on_line(7).in_column(17)
       end
 
       it 'should should add colons' do
@@ -105,6 +141,10 @@ describe 'relative_classname_inclusion' do
         include ::foobar
         include(::foobar)
         class { '::foobar': }
+        contain ::foobar
+        contain(::foobar)
+        require ::foobar
+        require(::foobar)
         EOS
         )
       end


### PR DESCRIPTION
Relative class inclusion can also occur using the contain and require
functions in addition to the include function. This commit adds support
for testing the use of those functions.

Fixes #1.
