### PR TITLE
Ignore 'require' function name appearing in resource parameters

### DIFF
--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -2,6 +2,7 @@ PuppetLint.new_check(:relative_classname_inclusion) do
   def check
     tokens.each_with_index do |token, token_idx|
       if token.type == :NAME && ['include','contain','require'].include?(token.value)
+        next if resource_indexes.any? { |resource| resource[:tokens].include?(token) }
         s = token.next_code_token
         in_function = 0
         while s.type != :NEWLINE

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -64,6 +64,21 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_warning(msg).on_line(7).in_column(17)
       end
     end
+
+    context 'when the require metadata parameter is used' do
+      let(:code) do
+        <<-EOS
+        file { '/path':
+          ensure  => present,
+          require => Shellvar['http_proxy'],
+        }
+        EOS
+      end
+
+      it 'should detect no problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do


### PR DESCRIPTION
The lint check previously checked all tokens and so erroneously detected
the 'require' metaparameter on a resource as a function call. All
matching tokens that are within a resource declaration are now excluded
from the lint check to ensure it only finds tokens in the main manifest
or class bodies.

Fixes #6
