### PR TITLE
Ignore function names followed by `=>` symbol

### DIFF
--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -2,8 +2,8 @@ PuppetLint.new_check(:relative_classname_inclusion) do
   def check
     tokens.each_with_index do |token, token_idx|
       if token.type == :NAME && ['include','contain','require'].include?(token.value)
-        next if resource_indexes.any? { |resource| resource[:tokens].include?(token) }
         s = token.next_code_token
+        next if s.type == :FARROW
         in_function = 0
         while s.type != :NEWLINE
           n = s.next_code_token

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -79,6 +79,23 @@ describe 'relative_classname_inclusion' do
         expect(problems).to have(0).problems
       end
     end
+
+    context 'when require is a hash key' do
+      let(:code) do
+        <<-EOS
+        $defaults = {
+          require => Exec['apt_update'],
+        }
+        $defaults = {
+          'require' => Exec['apt_update'],
+        }
+        EOS
+      end
+
+      it 'should detect no problems' do
+        expect(problems).to have(0).problems
+      end
+    end
   end
 
   context 'with fix enabled' do


### PR DESCRIPTION
Prevents bare words in hashes or resource parameters being interpreted
as function calls, as they'll always be followed by `=>`.

Fixes #9
