### PR TITLE
(#12) Fix undefined method type with lookup(foo).include

### DIFF
--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -3,6 +3,7 @@ PuppetLint.new_check(:relative_classname_inclusion) do
     tokens.each_with_index do |token, token_idx|
       if [:NAME,:FUNCTION_NAME].include?(token.type) && ['include','contain','require'].include?(token.value)
         s = token.next_code_token
+        next if s.nil?
         next if s.type == :FARROW
         in_function = 0
         while s.type != :NEWLINE

--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -1,13 +1,13 @@
 PuppetLint.new_check(:relative_classname_inclusion) do
   def check
     tokens.each_with_index do |token, token_idx|
-      if token.type == :NAME && ['include','contain','require'].include?(token.value)
+      if [:NAME,:FUNCTION_NAME].include?(token.type) && ['include','contain','require'].include?(token.value)
         s = token.next_code_token
         next if s.type == :FARROW
         in_function = 0
         while s.type != :NEWLINE
           n = s.next_code_token
-          if s.type == :NAME || s.type == :SSTRING
+          if [:NAME, :FUNCTION_NAME, :SSTRING,].include?(s.type)
             if n && n.type == :LPAREN
               in_function += 1
             elsif in_function > 0 && n && n.type == :RPAREN

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -182,4 +182,18 @@ describe 'relative_classname_inclusion' do
       end
     end
   end
+
+  describe '(#12) behavior of lookup("foo", {merge => unique}).include' do
+    let(:msg) { '(#12) class included with lookup("foo", {merge => unique}).include' }
+
+    let(:code) do
+      <<-EOS
+      lookup(foo, {merge => unique}).include
+      EOS
+    end
+
+    it 'should not detect any problems' do
+      expect(problems).to have(0).problems
+    end
+  end
 end


### PR DESCRIPTION
Without this patch, puppet-lint fails with a Puppet manifests containing the
line, `lookup('foo', {merge => unique}).include`.  The failure backtrace is:

    NoMethodError: undefined method `type' for nil:NilClass

This patch implements the recommendation by Rodjek in
https://github.com/rodjek/puppet-lint/issues/780

Fixes #12

Additional Spec Test Cleanup
===

This PR also gets the spec tests passing prior to the actual commit I'm trying
to fix:

Fix detection of functions with puppet-lint 2.3.3

Without this patch the spec tests are failing to catch problems when
functions are called with parenthesis.  For example, the following is not
caught and fixed:

    include(foobar)

This patch fixes the problem by adding a check for both :NAME and
:FUNCTION_NAME.  The symbol will be :NAME in the case of `include foobar` and
:FUNCTION_NAME in the case of `include(foobar)`.  This is necessary to get the
spec tests passing.