### PR TITLE
Add option to reverse the check

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ gem 'puppet-lint-absolute_classname-check', :require => false
 
 ### Relative class name inclusion
 
-Including a class by a relative name might lead to unexpected results [in Puppet 3](https://docs.puppet.com/puppet/3/lang_namespaces.html#relative-name-lookup-and-incorrect-name-resolution). This plugin is **not** recommended for use with Puppet code that has dropped support for Puppet 3 (EOL 20161231).
+Including a class by a relative name might lead to unexpected results [in Puppet 3](https://docs.puppet.com/puppet/3/lang_namespaces.html#relative-name-lookup-and-incorrect-name-resolution).
 
 #### What you have done
 
@@ -40,6 +40,14 @@ include foobar
 
 ```puppet
 include ::foobar
+```
+
+#### Reverse this check
+
+This check can be reversed to check for Puppet > 4.
+
+```ruby
+PuppetLint.configuration.absolute_classname_reverse = true
 ```
 
 #### Disabling the check

--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -1,10 +1,19 @@
 PuppetLint.new_check(:relative_classname_inclusion) do
   def check
     tokens.each_with_index do |token, token_idx|
+      reverse = PuppetLint.configuration.absolute_classname_reverse || false
+      if reverse
+        pattern = '^(?!::)'
+        message = 'class included by absolute name (::$class)'
+      else
+        pattern = '^::'
+        message = 'class included by relative name'
+      end
       if [:NAME,:FUNCTION_NAME].include?(token.type) && ['include','contain','require'].include?(token.value)
         s = token.next_code_token
         next if s.nil?
         next if s.type == :FARROW
+
         in_function = 0
         while s.type != :NEWLINE
           n = s.next_code_token
@@ -13,12 +22,12 @@ PuppetLint.new_check(:relative_classname_inclusion) do
               in_function += 1
             elsif in_function > 0 && n && n.type == :RPAREN
               in_function -= 1
-            elsif in_function == 0 && s.value !~ /^::/
+            elsif in_function.zero? && s.value !~ /#{pattern}/
               notify :warning, {
-                :message => 'class included by relative name',
-                :line    => s.line,
-                :column  => s.column,
-                :token   => s,
+                message: message,
+                line: s.line,
+                column: s.column,
+                token: s
               }
             end
           end
@@ -27,21 +36,26 @@ PuppetLint.new_check(:relative_classname_inclusion) do
       elsif token.type == :CLASS and token.next_code_token.type == :LBRACE
         s = token.next_code_token
         while s.type != :COLON
-          if (s.type == :NAME || s.type == :SSTRING) && s.value !~ /^::/
+          if (s.type == :NAME || s.type == :SSTRING) && s.value !~ /#{pattern}/
             notify :warning, {
-              :message => 'class included by relative name',
-              :line    => s.line,
-              :column  => s.column,
-              :token   => s,
+              message: message,
+              line: s.line,
+              column: s.column,
+              token: s
             }
           end
           s = s.next_token
         end
       end
     end
-  end 
+  end
 
   def fix(problem)
-    problem[:token].value = '::'+problem[:token].value
+    reverse = PuppetLint.configuration.absolute_classname_reverse || false
+    problem[:token].value = if reverse
+                              problem[:token].value[2..-1]
+                            else
+                              '::' + problem[:token].value
+                            end
   end
 end

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -1,34 +1,195 @@
 require 'spec_helper'
 
 describe 'relative_classname_inclusion' do
-  let(:msg) { 'class included by relative name' }
+  describe '(default)' do
+    let(:msg) { 'class included by relative name' }
 
-  context 'with fix disabled' do
-    context 'when absolute names are used' do
+    context 'with fix disabled' do
+      context 'when absolute names are used' do
+        let(:code) do
+          <<-EOS
+          include ::foobar
+          include('::foobar')
+          include(foobar(baz))
+          include(foobar('baz'))
+
+          include ::foo, ::bar
+          include('::foo', '::bar')
+
+          class { '::foobar': }
+
+          class foobar {
+          }
+
+          contain ::foobar
+          contain('::foobar')
+          contain(foobar(baz))
+          contain(foobar('baz'))
+
+          require ::foobar
+          require('::foobar')
+          require(foobar(baz))
+          require(foobar('baz'))
+          EOS
+        end
+
+        it 'should not detect any problems' do
+          expect(problems).to have(0).problems
+        end
+      end
+
+      context 'when relative names are used' do
+        let(:code) do
+          <<-EOS
+          include foobar
+          include(foobar)
+          class { 'foobar': }
+          contain foobar
+          contain(foobar)
+          require foobar
+          require(foobar)
+          EOS
+        end
+
+        it 'should detect 7 problems' do
+          expect(problems).to have(7).problems
+        end
+
+        it 'should create warnings' do
+          expect(problems).to contain_warning(msg).on_line(1).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(2).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(3).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(4).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(5).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(6).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(7).in_column(19)
+        end
+      end
+
+      context 'when the require metadata parameter is used' do
+        let(:code) do
+          <<-EOS
+          file { '/path':
+            ensure  => present,
+            require => Shellvar['http_proxy'],
+          }
+          EOS
+        end
+
+        it 'should detect no problems' do
+          expect(problems).to have(0).problems
+        end
+      end
+
+      context 'when require is a hash key' do
+        let(:code) do
+          <<-EOS
+          $defaults = {
+            require => Exec['apt_update'],
+          }
+          $defaults = {
+            'require' => Exec['apt_update'],
+          }
+          EOS
+        end
+
+        it 'should detect no problems' do
+          expect(problems).to have(0).problems
+        end
+      end
+    end
+
+    context 'with fix enabled' do
+      before do
+        PuppetLint.configuration.fix = true
+      end
+
+      after do
+        PuppetLint.configuration.fix = false
+      end
+
+      context 'when absolute names are used' do
+        let(:code) do
+          <<-EOS
+          include ::foobar
+          include('::foobar')
+          include(foobar(baz))
+          include(foobar('baz'))
+
+          include ::foo, ::bar
+          include('::foo', '::bar')
+
+          class { '::foobar': }
+
+          class foobar {
+          }
+
+          contain ::foobar
+          contain('::foobar')
+          contain(foobar(baz))
+          contain(foobar('baz'))
+
+          require ::foobar
+          require('::foobar')
+          require(foobar(baz))
+          require(foobar('baz'))
+          EOS
+        end
+
+        it 'should not detect any problems' do
+          expect(problems).to have(0).problems
+        end
+      end
+
+      context 'when relative names are used' do
+        let(:code) do
+          <<-EOS
+          include foobar
+          include(foobar)
+          class { 'foobar': }
+          contain foobar
+          contain(foobar)
+          require foobar
+          require(foobar)
+          EOS
+        end
+
+        it 'should detect 7 problems' do
+          expect(problems).to have(7).problems
+        end
+
+        it 'should fix the problems' do
+          expect(problems).to contain_fixed(msg).on_line(1).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(2).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(3).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(4).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(5).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(6).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(7).in_column(19)
+        end
+
+        it 'should should add colons' do
+          expect(manifest).to eq(
+          <<-EOS
+          include ::foobar
+          include(::foobar)
+          class { '::foobar': }
+          contain ::foobar
+          contain(::foobar)
+          require ::foobar
+          require(::foobar)
+          EOS
+          )
+        end
+      end
+    end
+
+    describe '(#12) behavior of lookup("foo", {merge => unique}).include' do
+      let(:msg) { '(#12) class included with lookup("foo", {merge => unique}).include' }
+
       let(:code) do
         <<-EOS
-        include ::foobar
-        include('::foobar')
-        include(foobar(baz))
-        include(foobar('baz'))
-
-        include ::foo, ::bar
-        include('::foo', '::bar')
-
-        class { '::foobar': }
-
-        class foobar {
-        }
-
-        contain ::foobar
-        contain('::foobar')
-        contain(foobar(baz))
-        contain(foobar('baz'))
-
-        require ::foobar
-        require('::foobar')
-        require(foobar(baz))
-        require(foobar('baz'))
+        lookup(foo, {merge => unique}).include
         EOS
       end
 
@@ -36,164 +197,229 @@ describe 'relative_classname_inclusion' do
         expect(problems).to have(0).problems
       end
     end
-
-    context 'when relative names are used' do
-      let(:code) do
-        <<-EOS
-        include foobar
-        include(foobar)
-        class { 'foobar': }
-        contain foobar
-        contain(foobar)
-        require foobar
-        require(foobar)
-        EOS
-      end
-
-      it 'should detect 7 problems' do
-        expect(problems).to have(7).problems
-      end
-
-      it 'should create warnings' do
-        expect(problems).to contain_warning(msg).on_line(1).in_column(17)
-        expect(problems).to contain_warning(msg).on_line(2).in_column(17)
-        expect(problems).to contain_warning(msg).on_line(3).in_column(17)
-        expect(problems).to contain_warning(msg).on_line(4).in_column(17)
-        expect(problems).to contain_warning(msg).on_line(5).in_column(17)
-        expect(problems).to contain_warning(msg).on_line(6).in_column(17)
-        expect(problems).to contain_warning(msg).on_line(7).in_column(17)
-      end
-    end
-
-    context 'when the require metadata parameter is used' do
-      let(:code) do
-        <<-EOS
-        file { '/path':
-          ensure  => present,
-          require => Shellvar['http_proxy'],
-        }
-        EOS
-      end
-
-      it 'should detect no problems' do
-        expect(problems).to have(0).problems
-      end
-    end
-
-    context 'when require is a hash key' do
-      let(:code) do
-        <<-EOS
-        $defaults = {
-          require => Exec['apt_update'],
-        }
-        $defaults = {
-          'require' => Exec['apt_update'],
-        }
-        EOS
-      end
-
-      it 'should detect no problems' do
-        expect(problems).to have(0).problems
-      end
-    end
   end
 
-  context 'with fix enabled' do
+  describe '(reversed)' do
     before do
-      PuppetLint.configuration.fix = true
+      PuppetLint.configuration.absolute_classname_reverse = true
+    end
+    let(:msg) { 'class included by absolute name (::$class)' }
+
+    context 'with fix disabled' do
+      context 'when absolute names are used' do
+        let(:code) do
+          <<-EOS
+          include ::foobar
+          include('::foobar')
+          include(foobar(baz))
+          include(foobar('baz'))
+
+          include ::foo, ::bar
+          include('::foo', '::bar')
+
+          class { '::foobar': }
+
+          class foobar {
+          }
+
+          contain ::foobar
+          contain('::foobar')
+          contain(foobar(baz))
+          contain(foobar('baz'))
+
+          require ::foobar
+          require('::foobar')
+          require(foobar(baz))
+          require(foobar('baz'))
+          EOS
+        end
+
+        it 'should detect 11 problems' do
+          expect(problems).to have(11).problems
+        end
+
+        it 'should create warnings' do
+          expect(problems).to contain_warning(msg).on_line(1).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(2).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(6).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(6).in_column(26)
+          expect(problems).to contain_warning(msg).on_line(7).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(7).in_column(28)
+          expect(problems).to contain_warning(msg).on_line(9).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(14).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(15).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(19).in_column(19)
+          expect(problems).to contain_warning(msg).on_line(20).in_column(19)
+        end
+      end
+
+      context 'when relative names are used' do
+        let(:code) do
+          <<-EOS
+          include foobar
+          include(foobar)
+          class { 'foobar': }
+          contain foobar
+          contain(foobar)
+          require foobar
+          require(foobar)
+          EOS
+        end
+
+        it 'should not detect a problem' do
+          expect(problems).to have(0).problems
+        end
+      end
+
+      context 'when the require metadata parameter is used' do
+        let(:code) do
+          <<-EOS
+          file { '/path':
+            ensure  => present,
+            require => Shellvar['http_proxy'],
+          }
+          EOS
+        end
+
+        it 'should detect no problems' do
+          expect(problems).to have(0).problems
+        end
+      end
+
+      context 'when require is a hash key' do
+        let(:code) do
+          <<-EOS
+          $defaults = {
+            require => Exec['apt_update'],
+          }
+          $defaults = {
+            'require' => Exec['apt_update'],
+          }
+          EOS
+        end
+
+        it 'should detect no problems' do
+          expect(problems).to have(0).problems
+        end
+      end
     end
 
-    after do
-      PuppetLint.configuration.fix = false
+    context 'with fix enabled' do
+      before do
+        PuppetLint.configuration.fix = true
+      end
+
+      after do
+        PuppetLint.configuration.fix = false
+      end
+
+      context 'when absolute names are used' do
+        let(:code) do
+          <<-EOS
+          include ::foobar
+          include('::foobar')
+          include(foobar(baz))
+          include(foobar('baz'))
+
+          include ::foo, ::bar
+          include('::foo', '::bar')
+
+          class { '::foobar': }
+
+          class foobar {
+          }
+
+          contain ::foobar
+          contain('::foobar')
+          contain(foobar(baz))
+          contain(foobar('baz'))
+
+          require ::foobar
+          require('::foobar')
+          require(foobar(baz))
+          require(foobar('baz'))
+          EOS
+        end
+
+        it 'should detect 11 problems' do
+          expect(problems).to have(11).problems
+        end
+
+        it 'should fix the problems' do
+          expect(problems).to contain_fixed(msg).on_line(1).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(2).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(6).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(6).in_column(26)
+          expect(problems).to contain_fixed(msg).on_line(7).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(7).in_column(28)
+          expect(problems).to contain_fixed(msg).on_line(9).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(14).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(15).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(19).in_column(19)
+          expect(problems).to contain_fixed(msg).on_line(20).in_column(19)
+        end
+
+        it 'should should remove colons' do
+          expect(manifest).to eq(
+          <<-EOS
+          include foobar
+          include('foobar')
+          include(foobar(baz))
+          include(foobar('baz'))
+
+          include foo, bar
+          include('foo', 'bar')
+
+          class { 'foobar': }
+
+          class foobar {
+          }
+
+          contain foobar
+          contain('foobar')
+          contain(foobar(baz))
+          contain(foobar('baz'))
+
+          require foobar
+          require('foobar')
+          require(foobar(baz))
+          require(foobar('baz'))
+          EOS
+          )
+        end
+      end
+
+      context 'when relative names are used' do
+        let(:code) do
+          <<-EOS
+          include foobar
+          include(foobar)
+          class { 'foobar': }
+          contain foobar
+          contain(foobar)
+          require foobar
+          require(foobar)
+          EOS
+        end
+
+        it 'should not detect any problems' do
+          expect(problems).to have(0).problems
+        end
+      end
     end
 
-    context 'when absolute names are used' do
+    describe '(#12) behavior of lookup("foo", {merge => unique}).include' do
+      let(:msg) { '(#12) class included with lookup("foo", {merge => unique}).include' }
+
       let(:code) do
         <<-EOS
-        include ::foobar
-        include('::foobar')
-        include(foobar(baz))
-        include(foobar('baz'))
-
-        include ::foo, ::bar
-        include('::foo', '::bar')
-
-        class { '::foobar': }
-
-        class foobar {
-        }
-
-        contain ::foobar
-        contain('::foobar')
-        contain(foobar(baz))
-        contain(foobar('baz'))
-
-        require ::foobar
-        require('::foobar')
-        require(foobar(baz))
-        require(foobar('baz'))
+        lookup(foo, {merge => unique}).include
         EOS
       end
 
       it 'should not detect any problems' do
         expect(problems).to have(0).problems
       end
-    end
-
-    context 'when relative names are used' do
-      let(:code) do
-        <<-EOS
-        include foobar
-        include(foobar)
-        class { 'foobar': }
-        contain foobar
-        contain(foobar)
-        require foobar
-        require(foobar)
-        EOS
-      end
-
-      it 'should detect 7 problems' do
-        expect(problems).to have(7).problems
-      end
-
-      it 'should fix the problems' do
-        expect(problems).to contain_fixed(msg).on_line(1).in_column(17)
-        expect(problems).to contain_fixed(msg).on_line(2).in_column(17)
-        expect(problems).to contain_fixed(msg).on_line(3).in_column(17)
-        expect(problems).to contain_fixed(msg).on_line(4).in_column(17)
-        expect(problems).to contain_fixed(msg).on_line(5).in_column(17)
-        expect(problems).to contain_fixed(msg).on_line(6).in_column(17)
-        expect(problems).to contain_fixed(msg).on_line(7).in_column(17)
-      end
-
-      it 'should should add colons' do
-        expect(manifest).to eq(
-        <<-EOS
-        include ::foobar
-        include(::foobar)
-        class { '::foobar': }
-        contain ::foobar
-        contain(::foobar)
-        require ::foobar
-        require(::foobar)
-        EOS
-        )
-      end
-    end
-  end
-
-  describe '(#12) behavior of lookup("foo", {merge => unique}).include' do
-    let(:msg) { '(#12) class included with lookup("foo", {merge => unique}).include' }
-
-    let(:code) do
-      <<-EOS
-      lookup(foo, {merge => unique}).include
-      EOS
-    end
-
-    it 'should not detect any problems' do
-      expect(problems).to have(0).problems
     end
   end
 end


### PR DESCRIPTION
Meaning: Warn if there are :: in front of a class definition.

Fixes #17.