### PR TITLE
Release 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v1.0.0](https://github.com/voxpupuli/puppet-lint-absolute_classname-check/tree/v1.0.0) (2019-02-09)
+## [2.0.0](https://github.com/voxpupuli/puppet-lint-absolute_classname-check/tree/2.0.0) (2019-12-06)
 
-[Full Changelog](https://github.com/voxpupuli/puppet-lint-absolute_classname-check/compare/0.2.5...v1.0.0)
+[Full Changelog](https://github.com/voxpupuli/puppet-lint-absolute_classname-check/compare/1.0.0...2.0.0)
+
+**Breaking changes:**
+
+- Drop reverse and always require Puppet 4+ style and Ruby 2.1 [\#21](https://github.com/voxpupuli/puppet-lint-absolute_classname-check/pull/21) ([ekohl](https://github.com/ekohl))
+
+## [1.0.0](https://github.com/voxpupuli/puppet-lint-absolute_classname-check/tree/1.0.0) (2019-02-09)
+
+[Full Changelog](https://github.com/voxpupuli/puppet-lint-absolute_classname-check/compare/0.2.5...1.0.0)
 
 **Closed issues:**
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@ Previously: https://github.com/camptocamp/puppet-lint-absolute_classname-check
 
 To make a new release, please do:
 * Update the version in the `puppet-lint-absolute_classname-check.gemspec` file
-* Update the version in the Rakefile
 * Install gems with `bundle install --with release --path .vendor`
 * generate the changelog with `bundle exec rake changelog`
 * Create a PR with it

--- a/Rakefile
+++ b/Rakefile
@@ -5,14 +5,15 @@ RSpec::Core::RakeTask.new(:spec)
 task :default => :spec
 
 begin
+  require 'rubygems'
   require 'github_changelog_generator/task'
+
   GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    version = '1.0.0'
-    config.future_release = "v#{version}" if version =~ /^\d+\.\d+.\d+$/
     config.header = "# Changelog\n\nAll notable changes to this project will be documented in this file."
     config.exclude_labels = %w{duplicate question invalid wontfix wont-fix skip-changelog}
     config.user = 'voxpupuli'
     config.project = 'puppet-lint-absolute_classname-check'
+    config.future_release = Gem::Specification.load("#{config.project}.gemspec").version
   end
 rescue LoadError
 end

--- a/puppet-lint-absolute_classname-check.gemspec
+++ b/puppet-lint-absolute_classname-check.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name        = 'puppet-lint-absolute_classname-check'
-  spec.version     = '1.0.0'
+  spec.version     = '2.0.0'
   spec.homepage    = 'https://github.com/voxpupuli/puppet-lint-absolute_classname-check'
   spec.license     = 'Apache-2.0'
   spec.author      = 'Vox Pupuli'

--- a/puppet-lint-absolute_classname-check.gemspec
+++ b/puppet-lint-absolute_classname-check.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency             'puppet-lint', '>= 1.0', '< 3.0'
   spec.add_development_dependency 'coveralls'
-  spec.add_development_dependency 'mime-types'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rspec-collection_matchers'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,5 @@
-unless RUBY_VERSION =~ /^1\.8/
-  require 'coveralls'
-  Coveralls.wear!
-end
+require 'coveralls'
+Coveralls.wear!
 
 require 'puppet-lint'
-
 PuppetLint::Plugins.load_spec_helper


### PR DESCRIPTION
This changes the Rakefile to not use the v prefix in tags. This is to stay consistent with all existing tags.