### PR TITLE
Add support for inherits and class references

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A puppet-lint plugin to check that classes are included by their absolute name.
   * [In a Gemfile](#in-a-gemfile)
 * [Checks](#checks)
   * [Relative class name inclusion](#relative-class-name-inclusion)
+  * [Relative class reference](#relative-classname-reference)
 * [Transfer notice](#transfer-notice)
 * [Release Informaion](#release-information)
 
@@ -64,6 +65,34 @@ Alternatively, if you’re calling puppet-lint via the Rake task, you should ins
 
 ```ruby
 PuppetLint.configuration.send('disable_relative_classname_inclusion')
+```
+
+### Relative class reference
+
+#### What you have done
+
+```puppet
+Class['::foo'] -> Class['::bar']
+```
+
+#### What you should have done
+
+```puppet
+Class['foo'] -> Class['bar']
+```
+
+#### Disabling the check
+
+To disable this check, you can add `--no-relative_classname_reference-check` to your puppet-lint command line.
+
+```shell
+$ puppet-lint --no-relative_classname_reference-check path/to/file.pp
+```
+
+Alternatively, if you’re calling puppet-lint via the Rake task, you should insert the following line to your `Rakefile`.
+
+```ruby
+PuppetLint.configuration.send('disable_relative_classname_reference')
 ```
 
 ## Transfer Notice

--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -50,19 +50,6 @@ PuppetLint.new_check(:relative_classname_inclusion) do
             token: s
           }
         end
-      elsif token.type == :TYPE and token.value == 'Class' and token.next_code_token.type == :LBRACK
-        s = token.next_code_token
-        while s.type != :RBRACK
-          if s.type == :SSTRING && s.value.start_with?('::')
-            notify :warning, {
-              message: message,
-              line: s.line,
-              column: s.column,
-              token: s
-            }
-          end
-          s = s.next_token
-        end
       end
     end
   end

--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -50,6 +50,19 @@ PuppetLint.new_check(:relative_classname_inclusion) do
             token: s
           }
         end
+      elsif token.type == :TYPE and token.value == 'Class' and token.next_code_token.type == :LBRACK
+        s = token.next_code_token
+        while s.type != :RBRACK
+          if s.type == :SSTRING && s.value.start_with?('::')
+            notify :warning, {
+              message: message,
+              line: s.line,
+              column: s.column,
+              token: s
+            }
+          end
+          s = s.next_token
+        end
       end
     end
   end

--- a/lib/puppet-lint/plugins/check_absolute_classname.rb
+++ b/lib/puppet-lint/plugins/check_absolute_classname.rb
@@ -40,6 +40,16 @@ PuppetLint.new_check(:relative_classname_inclusion) do
           end
           s = s.next_token
         end
+      elsif token.type == :INHERITS
+        s = token.next_code_token
+        if s.type == :NAME && s.value.start_with?('::')
+          notify :warning, {
+            message: message,
+            line: s.line,
+            column: s.column,
+            token: s
+          }
+        end
       end
     end
   end

--- a/lib/puppet-lint/plugins/check_classname_reference.rb
+++ b/lib/puppet-lint/plugins/check_classname_reference.rb
@@ -1,0 +1,26 @@
+PuppetLint.new_check(:relative_classname_reference) do
+  def check
+    message = 'absolute class name reference'
+
+    tokens.each_with_index do |token, token_idx|
+      if token.type == :TYPE and token.value == 'Class' and token.next_code_token.type == :LBRACK
+        s = token.next_code_token
+        while s.type != :RBRACK
+          if s.type == :SSTRING && s.value.start_with?('::')
+            notify :warning, {
+              message: message,
+              line: s.line,
+              column: s.column,
+              token: s
+            }
+          end
+          s = s.next_token
+        end
+      end
+    end
+  end
+
+  def fix(problem)
+    problem[:token].value = problem[:token].value[2..-1]
+  end
+end

--- a/lib/puppet-lint/plugins/check_classname_reference.rb
+++ b/lib/puppet-lint/plugins/check_classname_reference.rb
@@ -6,7 +6,7 @@ PuppetLint.new_check(:relative_classname_reference) do
       if token.type == :TYPE and token.value == 'Class' and token.next_code_token.type == :LBRACK
         s = token.next_code_token
         while s.type != :RBRACK
-          if s.type == :SSTRING && s.value.start_with?('::')
+          if (s.type == :NAME || s.type == :SSTRING) && s.value.start_with?('::')
             notify :warning, {
               message: message,
               line: s.line,

--- a/puppet-lint-absolute_classname-check.gemspec
+++ b/puppet-lint-absolute_classname-check.gemspec
@@ -12,9 +12,9 @@ Gem::Specification.new do |spec|
     'spec/**/*',
   ]
   spec.test_files  = Dir['spec/**/*']
-  spec.summary     = 'A puppet-lint plugin to check that classes are included by their absolute name.'
+  spec.summary     = 'A puppet-lint plugin to check that classes are included or referenced by their absolute name.'
   spec.description = <<-EOF
-    A puppet-lint plugin to check that classes are included by their absolute name.
+    A puppet-lint plugin to check that classes are included or referenced by their absolute name.
   EOF
 
   spec.required_ruby_version = '>= 2.1.0'

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -32,23 +32,11 @@ describe 'relative_classname_inclusion' do
 
         class foobar inherits ::baz {
         }
-
-        Class['::foo'] -> Class['::bar']
-
-        file { '/path':
-          ensure  => present,
-          require => Class['::foo', '::bar'],
-        }
-
-        file { '/path':
-          ensure  => present,
-          require => [Class['::foo'], Class['::bar']],
-        }
         EOS
       end
 
-      it 'should detect 18 problems' do
-        expect(problems).to have(18).problems
+      it 'should detect 12 problems' do
+        expect(problems).to have(12).problems
       end
 
       it 'should create warnings' do
@@ -64,12 +52,6 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_warning(msg).on_line(19).in_column(17)
         expect(problems).to contain_warning(msg).on_line(20).in_column(17)
         expect(problems).to contain_warning(msg).on_line(24).in_column(31)
-        expect(problems).to contain_warning(msg).on_line(27).in_column(15)
-        expect(problems).to contain_warning(msg).on_line(27).in_column(33)
-        expect(problems).to contain_warning(msg).on_line(31).in_column(28)
-        expect(problems).to contain_warning(msg).on_line(31).in_column(37)
-        expect(problems).to contain_warning(msg).on_line(36).in_column(29)
-        expect(problems).to contain_warning(msg).on_line(36).in_column(45)
       end
     end
 
@@ -84,15 +66,6 @@ describe 'relative_classname_inclusion' do
         require foobar
         require(foobar)
         class foobar inherits baz {
-        }
-        Class['foo'] -> Class['bar']
-        file { '/path':
-          ensure  => present,
-          require => Class['foo', 'bar'],
-        }
-        file { '/path':
-          ensure  => present,
-          require => [Class['foo'], Class['bar']],
         }
         EOS
       end
@@ -172,23 +145,11 @@ describe 'relative_classname_inclusion' do
 
         class foobar inherits ::baz {
         }
-
-        Class['::foo'] -> Class['::bar']
-
-        file { '/path':
-          ensure  => present,
-          require => Class['::foo', '::bar'],
-        }
-
-        file { '/path':
-          ensure  => present,
-          require => [Class['::foo'], Class['::bar']],
-        }
         EOS
       end
 
-      it 'should detect 18 problems' do
-        expect(problems).to have(18).problems
+      it 'should detect 12 problems' do
+        expect(problems).to have(12).problems
       end
 
       it 'should fix the problems' do
@@ -204,12 +165,6 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_fixed(msg).on_line(19).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(20).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(24).in_column(31)
-        expect(problems).to contain_fixed(msg).on_line(27).in_column(15)
-        expect(problems).to contain_fixed(msg).on_line(27).in_column(33)
-        expect(problems).to contain_fixed(msg).on_line(31).in_column(28)
-        expect(problems).to contain_fixed(msg).on_line(31).in_column(37)
-        expect(problems).to contain_fixed(msg).on_line(36).in_column(29)
-        expect(problems).to contain_fixed(msg).on_line(36).in_column(45)
       end
 
       it 'should should remove colons' do
@@ -240,18 +195,6 @@ describe 'relative_classname_inclusion' do
 
         class foobar inherits baz {
         }
-
-        Class['foo'] -> Class['bar']
-
-        file { '/path':
-          ensure  => present,
-          require => Class['foo', 'bar'],
-        }
-
-        file { '/path':
-          ensure  => present,
-          require => [Class['foo'], Class['bar']],
-        }
         EOS
         )
       end
@@ -268,15 +211,6 @@ describe 'relative_classname_inclusion' do
         require foobar
         require(foobar)
         class foobar inherits baz {
-        }
-        Class['foo'] -> Class['bar']
-        file { '/path':
-          ensure  => present,
-          require => Class['foo', 'bar'],
-        }
-        file { '/path':
-          ensure  => present,
-          require => [Class['foo'], Class['bar']],
         }
         EOS
       end

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -32,11 +32,13 @@ describe 'relative_classname_inclusion' do
 
         class foobar inherits ::baz {
         }
+
+        Class['::foo'] -> Class['::bar']
         EOS
       end
 
-      it 'should detect 12 problems' do
-        expect(problems).to have(12).problems
+      it 'should detect 14 problems' do
+        expect(problems).to have(14).problems
       end
 
       it 'should create warnings' do
@@ -52,6 +54,8 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_warning(msg).on_line(19).in_column(17)
         expect(problems).to contain_warning(msg).on_line(20).in_column(17)
         expect(problems).to contain_warning(msg).on_line(24).in_column(31)
+        expect(problems).to contain_warning(msg).on_line(27).in_column(15)
+        expect(problems).to contain_warning(msg).on_line(27).in_column(33)
       end
     end
 
@@ -67,6 +71,7 @@ describe 'relative_classname_inclusion' do
         require(foobar)
         class foobar inherits baz {
         }
+        Class['foo'] -> Class['bar']
         EOS
       end
 
@@ -145,11 +150,13 @@ describe 'relative_classname_inclusion' do
 
         class foobar inherits ::baz {
         }
+
+        Class['::foo'] -> Class['::bar']
         EOS
       end
 
-      it 'should detect 12 problems' do
-        expect(problems).to have(12).problems
+      it 'should detect 14 problems' do
+        expect(problems).to have(14).problems
       end
 
       it 'should fix the problems' do
@@ -165,6 +172,8 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_fixed(msg).on_line(19).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(20).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(24).in_column(31)
+        expect(problems).to contain_fixed(msg).on_line(27).in_column(15)
+        expect(problems).to contain_fixed(msg).on_line(27).in_column(33)
       end
 
       it 'should should remove colons' do
@@ -195,6 +204,8 @@ describe 'relative_classname_inclusion' do
 
         class foobar inherits baz {
         }
+
+        Class['foo'] -> Class['bar']
         EOS
         )
       end
@@ -212,6 +223,7 @@ describe 'relative_classname_inclusion' do
         require(foobar)
         class foobar inherits baz {
         }
+        Class['foo'] -> Class['bar']
         EOS
       end
 

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -29,11 +29,14 @@ describe 'relative_classname_inclusion' do
         require('::foobar')
         require(foobar(baz))
         require(foobar('baz'))
+
+        class foobar inherits ::baz {
+        }
         EOS
       end
 
-      it 'should detect 11 problems' do
-        expect(problems).to have(11).problems
+      it 'should detect 12 problems' do
+        expect(problems).to have(12).problems
       end
 
       it 'should create warnings' do
@@ -48,6 +51,7 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_warning(msg).on_line(15).in_column(17)
         expect(problems).to contain_warning(msg).on_line(19).in_column(17)
         expect(problems).to contain_warning(msg).on_line(20).in_column(17)
+        expect(problems).to contain_warning(msg).on_line(24).in_column(31)
       end
     end
 
@@ -61,6 +65,8 @@ describe 'relative_classname_inclusion' do
         contain(foobar)
         require foobar
         require(foobar)
+        class foobar inherits baz {
+        }
         EOS
       end
 
@@ -136,11 +142,14 @@ describe 'relative_classname_inclusion' do
         require('::foobar')
         require(foobar(baz))
         require(foobar('baz'))
+
+        class foobar inherits ::baz {
+        }
         EOS
       end
 
-      it 'should detect 11 problems' do
-        expect(problems).to have(11).problems
+      it 'should detect 12 problems' do
+        expect(problems).to have(12).problems
       end
 
       it 'should fix the problems' do
@@ -155,6 +164,7 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_fixed(msg).on_line(15).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(19).in_column(17)
         expect(problems).to contain_fixed(msg).on_line(20).in_column(17)
+        expect(problems).to contain_fixed(msg).on_line(24).in_column(31)
       end
 
       it 'should should remove colons' do
@@ -182,6 +192,9 @@ describe 'relative_classname_inclusion' do
         require('foobar')
         require(foobar(baz))
         require(foobar('baz'))
+
+        class foobar inherits baz {
+        }
         EOS
         )
       end
@@ -197,6 +210,8 @@ describe 'relative_classname_inclusion' do
         contain(foobar)
         require foobar
         require(foobar)
+        class foobar inherits baz {
+        }
         EOS
       end
 

--- a/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
+++ b/spec/puppet-lint/plugins/check_absolute_classname/relative_classname_inclusion_spec.rb
@@ -34,11 +34,21 @@ describe 'relative_classname_inclusion' do
         }
 
         Class['::foo'] -> Class['::bar']
+
+        file { '/path':
+          ensure  => present,
+          require => Class['::foo', '::bar'],
+        }
+
+        file { '/path':
+          ensure  => present,
+          require => [Class['::foo'], Class['::bar']],
+        }
         EOS
       end
 
-      it 'should detect 14 problems' do
-        expect(problems).to have(14).problems
+      it 'should detect 18 problems' do
+        expect(problems).to have(18).problems
       end
 
       it 'should create warnings' do
@@ -56,6 +66,10 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_warning(msg).on_line(24).in_column(31)
         expect(problems).to contain_warning(msg).on_line(27).in_column(15)
         expect(problems).to contain_warning(msg).on_line(27).in_column(33)
+        expect(problems).to contain_warning(msg).on_line(31).in_column(28)
+        expect(problems).to contain_warning(msg).on_line(31).in_column(37)
+        expect(problems).to contain_warning(msg).on_line(36).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(36).in_column(45)
       end
     end
 
@@ -72,6 +86,14 @@ describe 'relative_classname_inclusion' do
         class foobar inherits baz {
         }
         Class['foo'] -> Class['bar']
+        file { '/path':
+          ensure  => present,
+          require => Class['foo', 'bar'],
+        }
+        file { '/path':
+          ensure  => present,
+          require => [Class['foo'], Class['bar']],
+        }
         EOS
       end
 
@@ -152,11 +174,21 @@ describe 'relative_classname_inclusion' do
         }
 
         Class['::foo'] -> Class['::bar']
+
+        file { '/path':
+          ensure  => present,
+          require => Class['::foo', '::bar'],
+        }
+
+        file { '/path':
+          ensure  => present,
+          require => [Class['::foo'], Class['::bar']],
+        }
         EOS
       end
 
-      it 'should detect 14 problems' do
-        expect(problems).to have(14).problems
+      it 'should detect 18 problems' do
+        expect(problems).to have(18).problems
       end
 
       it 'should fix the problems' do
@@ -174,6 +206,10 @@ describe 'relative_classname_inclusion' do
         expect(problems).to contain_fixed(msg).on_line(24).in_column(31)
         expect(problems).to contain_fixed(msg).on_line(27).in_column(15)
         expect(problems).to contain_fixed(msg).on_line(27).in_column(33)
+        expect(problems).to contain_fixed(msg).on_line(31).in_column(28)
+        expect(problems).to contain_fixed(msg).on_line(31).in_column(37)
+        expect(problems).to contain_fixed(msg).on_line(36).in_column(29)
+        expect(problems).to contain_fixed(msg).on_line(36).in_column(45)
       end
 
       it 'should should remove colons' do
@@ -206,6 +242,16 @@ describe 'relative_classname_inclusion' do
         }
 
         Class['foo'] -> Class['bar']
+
+        file { '/path':
+          ensure  => present,
+          require => Class['foo', 'bar'],
+        }
+
+        file { '/path':
+          ensure  => present,
+          require => [Class['foo'], Class['bar']],
+        }
         EOS
         )
       end
@@ -224,6 +270,14 @@ describe 'relative_classname_inclusion' do
         class foobar inherits baz {
         }
         Class['foo'] -> Class['bar']
+        file { '/path':
+          ensure  => present,
+          require => Class['foo', 'bar'],
+        }
+        file { '/path':
+          ensure  => present,
+          require => [Class['foo'], Class['bar']],
+        }
         EOS
       end
 

--- a/spec/puppet-lint/plugins/check_classname_reference/relative_classname_reference_spec.rb
+++ b/spec/puppet-lint/plugins/check_classname_reference/relative_classname_reference_spec.rb
@@ -1,0 +1,137 @@
+require 'spec_helper'
+
+describe 'relative_classname_reference' do
+  let(:msg) { 'absolute class name reference' }
+
+  context 'with fix disabled' do
+    context 'when absolute names are used' do
+      let(:code) do
+        <<-EOS
+        Class['::foo'] -> Class['::bar']
+
+        file { '/path':
+          ensure  => present,
+          require => Class['::foo', '::bar'],
+        }
+
+        file { '/path':
+          ensure  => present,
+          require => [Class['::foo'], Class['::bar']],
+        }
+        EOS
+      end
+
+      it 'should detect 6 problems' do
+        expect(problems).to have(6).problems
+      end
+
+      it 'should create warnings' do
+        expect(problems).to contain_warning(msg).on_line(1).in_column(15)
+        expect(problems).to contain_warning(msg).on_line(1).in_column(33)
+        expect(problems).to contain_warning(msg).on_line(5).in_column(28)
+        expect(problems).to contain_warning(msg).on_line(5).in_column(37)
+        expect(problems).to contain_warning(msg).on_line(10).in_column(29)
+        expect(problems).to contain_warning(msg).on_line(10).in_column(45)
+      end
+    end
+
+    context 'when relative names are used' do
+      let(:code) do
+        <<-EOS
+        Class['foo'] -> Class['bar']
+        file { '/path':
+          ensure  => present,
+          require => Class['foo', 'bar'],
+        }
+        file { '/path':
+          ensure  => present,
+          require => [Class['foo'], Class['bar']],
+        }
+        EOS
+      end
+
+      it 'should not detect a problem' do
+        expect(problems).to have(0).problems
+      end
+    end
+  end
+
+  context 'with fix enabled' do
+    before do
+      PuppetLint.configuration.fix = true
+    end
+
+    after do
+      PuppetLint.configuration.fix = false
+    end
+
+    context 'when absolute names are used' do
+      let(:code) do
+        <<-EOS
+        Class['::foo'] -> Class['::bar']
+
+        file { '/path':
+          ensure  => present,
+          require => Class['::foo', '::bar'],
+        }
+
+        file { '/path':
+          ensure  => present,
+          require => [Class['::foo'], Class['::bar']],
+        }
+        EOS
+      end
+
+      it 'should detect 6 problems' do
+        expect(problems).to have(6).problems
+      end
+
+      it 'should fix the problems' do
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(15)
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(33)
+        expect(problems).to contain_fixed(msg).on_line(5).in_column(28)
+        expect(problems).to contain_fixed(msg).on_line(5).in_column(37)
+        expect(problems).to contain_fixed(msg).on_line(10).in_column(29)
+        expect(problems).to contain_fixed(msg).on_line(10).in_column(45)
+      end
+
+      it 'should should remove colons' do
+        expect(manifest).to eq(
+        <<-EOS
+        Class['foo'] -> Class['bar']
+
+        file { '/path':
+          ensure  => present,
+          require => Class['foo', 'bar'],
+        }
+
+        file { '/path':
+          ensure  => present,
+          require => [Class['foo'], Class['bar']],
+        }
+        EOS
+        )
+      end
+    end
+
+    context 'when relative names are used' do
+      let(:code) do
+        <<-EOS
+        Class['foo'] -> Class['bar']
+        file { '/path':
+          ensure  => present,
+          require => Class['foo', 'bar'],
+        }
+        file { '/path':
+          ensure  => present,
+          require => [Class['foo'], Class['bar']],
+        }
+        EOS
+      end
+
+      it 'should not detect any problems' do
+        expect(problems).to have(0).problems
+      end
+    end
+  end
+end

--- a/spec/puppet-lint/plugins/check_classname_reference/relative_classname_reference_spec.rb
+++ b/spec/puppet-lint/plugins/check_classname_reference/relative_classname_reference_spec.rb
@@ -7,7 +7,7 @@ describe 'relative_classname_reference' do
     context 'when absolute names are used' do
       let(:code) do
         <<-EOS
-        Class['::foo'] -> Class['::bar']
+        Class[::foo] -> Class['::bar']
 
         file { '/path':
           ensure  => present,
@@ -16,7 +16,7 @@ describe 'relative_classname_reference' do
 
         file { '/path':
           ensure  => present,
-          require => [Class['::foo'], Class['::bar']],
+          require => [Class[::foo], Class['::bar']],
         }
         EOS
       end
@@ -27,18 +27,18 @@ describe 'relative_classname_reference' do
 
       it 'should create warnings' do
         expect(problems).to contain_warning(msg).on_line(1).in_column(15)
-        expect(problems).to contain_warning(msg).on_line(1).in_column(33)
+        expect(problems).to contain_warning(msg).on_line(1).in_column(31)
         expect(problems).to contain_warning(msg).on_line(5).in_column(28)
         expect(problems).to contain_warning(msg).on_line(5).in_column(37)
         expect(problems).to contain_warning(msg).on_line(10).in_column(29)
-        expect(problems).to contain_warning(msg).on_line(10).in_column(45)
+        expect(problems).to contain_warning(msg).on_line(10).in_column(43)
       end
     end
 
     context 'when relative names are used' do
       let(:code) do
         <<-EOS
-        Class['foo'] -> Class['bar']
+        Class[foo] -> Class['bar']
         file { '/path':
           ensure  => present,
           require => Class['foo', 'bar'],
@@ -68,7 +68,7 @@ describe 'relative_classname_reference' do
     context 'when absolute names are used' do
       let(:code) do
         <<-EOS
-        Class['::foo'] -> Class['::bar']
+        Class[::foo] -> Class['::bar']
 
         file { '/path':
           ensure  => present,
@@ -77,7 +77,7 @@ describe 'relative_classname_reference' do
 
         file { '/path':
           ensure  => present,
-          require => [Class['::foo'], Class['::bar']],
+          require => [Class[::foo], Class['::bar']],
         }
         EOS
       end
@@ -88,17 +88,17 @@ describe 'relative_classname_reference' do
 
       it 'should fix the problems' do
         expect(problems).to contain_fixed(msg).on_line(1).in_column(15)
-        expect(problems).to contain_fixed(msg).on_line(1).in_column(33)
+        expect(problems).to contain_fixed(msg).on_line(1).in_column(31)
         expect(problems).to contain_fixed(msg).on_line(5).in_column(28)
         expect(problems).to contain_fixed(msg).on_line(5).in_column(37)
         expect(problems).to contain_fixed(msg).on_line(10).in_column(29)
-        expect(problems).to contain_fixed(msg).on_line(10).in_column(45)
+        expect(problems).to contain_fixed(msg).on_line(10).in_column(43)
       end
 
       it 'should should remove colons' do
         expect(manifest).to eq(
         <<-EOS
-        Class['foo'] -> Class['bar']
+        Class[foo] -> Class['bar']
 
         file { '/path':
           ensure  => present,
@@ -107,7 +107,7 @@ describe 'relative_classname_reference' do
 
         file { '/path':
           ensure  => present,
-          require => [Class['foo'], Class['bar']],
+          require => [Class[foo], Class['bar']],
         }
         EOS
         )
@@ -117,14 +117,14 @@ describe 'relative_classname_reference' do
     context 'when relative names are used' do
       let(:code) do
         <<-EOS
-        Class['foo'] -> Class['bar']
+        Class[foo] -> Class['bar']
         file { '/path':
           ensure  => present,
           require => Class['foo', 'bar'],
         }
         file { '/path':
           ensure  => present,
-          require => [Class['foo'], Class['bar']],
+          require => [Class[foo], Class['bar']],
         }
         EOS
       end


### PR DESCRIPTION
Now detects violations such as:
```puppet
class foo inherits ::bar {}
```
and
```puppet
Class['::foo'] -> Class['::bar']
```
Fixes #20